### PR TITLE
PM2 hardcoded home directory fix

### DIFF
--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -6,9 +6,9 @@ module.exports = {
 		// Logging configuration
 		log_date_format: 'HH:mm:ss.SSS DD.MM.YYYY',
 		merge_logs: true,
-		log_file: '/home/sefinek/logs/other/waf/combined.log',
-		out_file: '/home/sefinek/logs/other/waf/out.log',
-		error_file: '/home/sefinek/logs/other/waf/error.log',
+		log_file: '~/logs/other/waf/combined.log',
+		out_file: '~/logs/other/waf/out.log',
+		error_file: '~/logs/other/waf/error.log',
 
 		// Application restart policy settings
 		wait_ready: true,


### PR DESCRIPTION
PM2 permission error on start:
```
[PM2][WARN] Applications waf not running, starting...
[PM2][WARN] Folder does not exist: /home/sefinek/logs/other/waf
[PM2] Creating folder: /home/sefinek/logs/other/waf
[PM2][ERROR] Could not create folder: /home/sefinek/logs/other/waf
[PM2][ERROR] Error: Could not create folder
```

## Changes
- Changed `/home/sefinek` to `~` in order to avoid permission issues when generating logs